### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,9 +129,9 @@ Exemple pour afficher les sondages terminés :
 </BOUCLE_sondages_terminees>
 ```
 
-### Modèle
+### Contenu d'article ou de rubrique
 
-Il est possible d'insérer un modèle dans les contenus. Le code à insérer est `<sondageXX>` où `XX` correspond à l'`id_sondage` du sondage.
+Il est possible d'insérer un sondage dans les contenus. Le code à insérer est `<formulaire|sondage|id_sondage=XX>` où `XX` correspond à l'identifiant du sondage.
 
 ### Saisie sondage
 


### PR DESCRIPTION
L'option d'insérer un sondage via un modèle pose des problèmes de gestion du cache de SPIP. Un utilisateur tout frais peut afficher une page avec le résultat du sondage alors qu'il souhaiterait pouvoir y répondre du fait que les modèles sont enregistrés dans le cache. En appelant directement le formulaire, celui-ci est régénéré à chaque visite de page (cf. http://forum.spip.net/fr_226084.html#forum264403).
